### PR TITLE
Fix asset not found issue (#46)

### DIFF
--- a/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/SqlFederatedCacheStoreExtension.java
+++ b/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/SqlFederatedCacheStoreExtension.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Requires;
-import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
@@ -30,8 +29,7 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 @Extension(value = SqlFederatedCacheStoreExtension.NAME)
 @Requires(value = {
         DataSourceRegistry.class,
-        TransactionContext.class,
-        AssetIndex.class
+        TransactionContext.class
 })
 public class SqlFederatedCacheStoreExtension implements ServiceExtension {
 
@@ -41,8 +39,6 @@ public class SqlFederatedCacheStoreExtension implements ServiceExtension {
     private DataSourceRegistry dataSourceRegistry;
     @Inject
     private TransactionContext transactionContext;
-    @Inject
-    private AssetIndex assetIndex;
 
     @Override
     public String name() {
@@ -56,8 +52,7 @@ public class SqlFederatedCacheStoreExtension implements ServiceExtension {
                 DataSourceRegistry.DEFAULT_DATASOURCE,
                 transactionContext,
                 context.getTypeManager().getMapper(),
-                new PostgresDialectStatements(),
-                assetIndex
+                new PostgresDialectStatements()
         );
     }
 }

--- a/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/BaseSqlDialectStatements.java
+++ b/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/BaseSqlDialectStatements.java
@@ -25,17 +25,18 @@ public class BaseSqlDialectStatements implements ContractOfferStatements {
 
     @Override
     public String getInsertTemplate() {
-        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?%s, ?, ?, ?, ?, ?, ?, ?)",
+        return format("INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES (?, ?%s, ?%s, ?, ?, ?, ?, ?, ?)",
                 getContractOfferTable(),
                 getIdColumn(),
                 getPolicyColumn(),
-                getAssetIdColumn(),
+                getAssetColumn(),
                 getUriProviderColumn(),
                 getUriConsumerColumn(),
                 getOfferStartColumn(),
                 getOfferEndColumn(),
                 getContractStartColumn(),
                 getContractEndColumn(),
+                getFormatAsJsonOperator(),
                 getFormatAsJsonOperator()
         );
     }

--- a/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/ContractOfferStatements.java
+++ b/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/ContractOfferStatements.java
@@ -33,8 +33,8 @@ public interface ContractOfferStatements {
         return "policy";
     }
 
-    default String getAssetIdColumn() {
-        return "asset_id";
+    default String getAssetColumn() {
+        return "asset";
     }
 
     default String getUriProviderColumn() {

--- a/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/postgres/ContractOfferMapping.java
+++ b/extensions/store/fcc-store-sql/src/main/java/de/truzzt/edc/extension/catalog/cache/sql/schema/postgres/ContractOfferMapping.java
@@ -22,7 +22,7 @@ public class ContractOfferMapping extends TranslationMapping {
     public ContractOfferMapping(ContractOfferStatements statements) {
         add("id", statements.getIdColumn());
         add("policy", statements.getPolicyColumn());
-        add("asset", statements.getAssetIdColumn());
+        add("asset", statements.getAssetColumn());
         add("uriProvider", statements.getUriProviderColumn());
         add("uriConsumer", statements.getUriConsumerColumn());
         add("offerStart", statements.getOfferStartColumn());

--- a/extensions/store/fcc-store-sql/src/test/java/de/truzzt/edc/extension/catalog/cache/sql/PostgresFederatedCacheStoreTest.java
+++ b/extensions/store/fcc-store-sql/src/test/java/de/truzzt/edc/extension/catalog/cache/sql/PostgresFederatedCacheStoreTest.java
@@ -19,10 +19,8 @@ import de.truzzt.edc.extension.catalog.cache.sql.schema.postgres.PostgresDialect
 import de.truzzt.edc.extension.catalog.cache.test.TestUtil;
 import de.truzzt.edc.extension.postgresql.migration.DatabaseMigrationManager;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractOffer;
-import org.eclipse.edc.connector.defaults.storage.assetindex.InMemoryAssetIndex;
 import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
 import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
-import org.eclipse.edc.spi.asset.AssetIndex;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -48,8 +46,6 @@ class PostgresFederatedCacheStoreTest {
 
     private final BaseSqlDialectStatements sqlStatements = new PostgresDialectStatements();
 
-    private final AssetIndex assetIndex = new InMemoryAssetIndex();
-
     private SqlFederatedCacheStore federatedCacheStore;
 
     private DatabaseMigrationManager migrationManager;
@@ -63,7 +59,7 @@ class PostgresFederatedCacheStoreTest {
         migrationManager.migrateAllDataSources(false);
 
         federatedCacheStore = new SqlFederatedCacheStore(setupExtension.getDataSourceRegistry(), setupExtension.getDatasourceName(),
-                setupExtension.getTransactionContext(), typeManager.getMapper(), sqlStatements, assetIndex);
+                setupExtension.getTransactionContext(), typeManager.getMapper(), sqlStatements);
     }
 
     @AfterEach
@@ -179,7 +175,6 @@ class PostgresFederatedCacheStoreTest {
 
         var dataAddress = TestUtil.createDataAddress("test-address" + i);
         var asset = TestUtil.createAsset("test-asset" + i);
-        assetIndex.accept(new AssetEntry(asset, dataAddress));
 
         return TestUtil.createOffer("test-offer" + i, asset);
     }

--- a/extensions/store/fcc-store-sql/src/test/java/de/truzzt/edc/extension/catalog/cache/sql/PostgresFederatedCacheStoreTest.java
+++ b/extensions/store/fcc-store-sql/src/test/java/de/truzzt/edc/extension/catalog/cache/sql/PostgresFederatedCacheStoreTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.policy.model.PolicyRegistrationTypes;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.spi.types.domain.asset.AssetEntry;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/extensions/store/postgres-flyway/src/main/resources/migration/default/V0003__asset_embedding.sql
+++ b/extensions/store/postgres-flyway/src/main/resources/migration/default/V0003__asset_embedding.sql
@@ -1,0 +1,3 @@
+ALTER TABLE edc_contract_offer
+    ADD COLUMN asset JSON NOT NULL,
+    DROP COLUMN asset_id;


### PR DESCRIPTION
## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

Fixes #46

## Why it does that

_Briefly state why the change was necessary._

It embeds the Asset into the `edc_contract_offer` table. Removes the dependency on `AssetIndex` in the `fcc-store-sql`

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Database table `edc_contract_offer` should be cleaned. No data migration possible, due to this bug making the usage of this extension not possible.

## Linked Issue(s)

Closes #46 <-- _insert Issue number if one exists_
