### PR TITLE
Fix Broker loads max 50 workitems

### DIFF
--- a/extensions/store/fcc-node-directory-sql/src/main/java/de/truzzt/edc/extension/catalog/directory/sql/SqlFederatedNodeDirectory.java
+++ b/extensions/store/fcc-node-directory-sql/src/main/java/de/truzzt/edc/extension/catalog/directory/sql/SqlFederatedNodeDirectory.java
@@ -55,7 +55,8 @@ public class SqlFederatedNodeDirectory extends AbstractSqlStore implements Feder
 
         return transactionContext.execute(() -> {
             try {
-                var statement = statements.createQuery(QuerySpec.Builder.newInstance().build());
+                // TODO Implement a definite solution for the query limit. Temporary fix using 5000 as limit.
+                var statement = statements.createQuery(QuerySpec.Builder.newInstance().limit(5000).build());
                 return executeQuery(getConnection(), true, this::mapResultSet, statement.getQueryAsString(), statement.getParameters())
                         .collect(Collectors.toList());
             } catch (SQLException e) {


### PR DESCRIPTION
## What this PR changes/adds

Sets the `SqlFederatedNodeDirectory.getAll()` query limit to a fixed value of 5000.

## Why it does that

Fix the limitation of 50 work items loaded in the crawler execution instead of the real number of registered connectors.

## Linked Issue(s)
https://github.com/truzzt/FederatedCatalog/issues/47
